### PR TITLE
Measure shimmer width based on a placeholder text

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Provide both TextView and ImageView the ability to show shimmer (animation loade
          android:layout_height="wrap_content"
          app:width_weight="0.4" />
     ```
+    
+    Alternatively, you can set a placeholder which will be used to measure the required minimum width, so the shimmer will
+    almost be as large as your text
+    ```xml
+    <com.elyeproj.loaderviewlibrary.LoaderTextView
+         android:layout_width="wrap_content"
+         android:layout_height="wrap_content"
+         app:placeholder_int_argument="1"
+         app:placeholder_resource="@string/resourceWithIntArgument" />
+    ```
+    
+    Referencing a string resource makes sure the shimmer respects text width in different
+    languages. You can optionally pass one `String`, `int` or `float` argument. If you need more than
+    one argument you have to use `setPlaceholder(String)` programmatically.
 
 4. Define the % height of the TextView that shows the loading animation with `height_weight`
     ```xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.elyeproj.sampleloaderview"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -20,8 +20,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile project(':loaderviewlibrary')
-    compile 'com.android.support:appcompat-v7:26.1.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation project(':loaderviewlibrary')
+    implementation 'com.android.support:appcompat-v7:27.1.0'
 }

--- a/app/src/main/java/com/elyeproj/sampleloaderview/MainActivity.java
+++ b/app/src/main/java/com/elyeproj/sampleloaderview/MainActivity.java
@@ -31,6 +31,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void postLoadData() {
+        ((TextView)findViewById(R.id.txt_presidents_title)).setText(getString(R.string.title, 1));
         ((TextView)findViewById(R.id.txt_name)).setText("Mr. Donald Trump");
         ((TextView)findViewById(R.id.txt_title)).setText("President of United State (2017 - now)");
         ((TextView)findViewById(R.id.txt_phone)).setText("+001 2345 6789");

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,19 +15,29 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <com.elyeproj.loaderviewlibrary.LoaderTextView
+            android:id="@+id/txt_presidents_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:placeholder_int_argument="1"
+            app:placeholder_resource="@string/title" />
+
         <com.elyeproj.loaderviewlibrary.LoaderImageView
             android:id="@+id/image_icon"
             android:layout_width="100dp"
             android:layout_height="100dp"
+            android:layout_below="@id/txt_presidents_title"
             android:layout_marginEnd="16dp"
             android:layout_marginRight="16dp"
-            app:use_gradient="true"
-            app:corners="16" />
+            android:layout_marginTop="@dimen/activity_vertical_margin"
+            app:corners="16"
+            app:use_gradient="true" />
 
         <LinearLayout
             android:id="@+id/container_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_alignTop="@id/image_icon"
             android:layout_centerVertical="true"
             android:layout_toEndOf="@id/image_icon"
             android:layout_toRightOf="@id/image_icon"
@@ -49,9 +59,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:textSize="@dimen/standard_font_size"
+                app:corners="32"
                 app:height_weight="0.8"
-                app:width_weight="1.0"
-                app:corners="32" />
+                app:width_weight="1.0" />
 
             <com.elyeproj.loaderviewlibrary.LoaderTextView
                 android:id="@+id/txt_phone"
@@ -59,12 +69,12 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:drawableLeft="@drawable/ic_phone_grey_500_18dp"
-                android:drawableStart="@drawable/ic_phone_grey_500_18dp"
                 android:drawablePadding="8dp"
+                android:drawableStart="@drawable/ic_phone_grey_500_18dp"
                 android:textSize="@dimen/standard_font_size"
+                app:corners="16"
                 app:height_weight="0.8"
-                app:width_weight="0.4"
-                app:corners="16" />
+                app:width_weight="0.4" />
 
             <com.elyeproj.loaderviewlibrary.LoaderTextView
                 android:id="@+id/txt_email"
@@ -72,12 +82,12 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:drawableLeft="@drawable/ic_mail_outline_grey_500_18dp"
-                android:drawableStart="@drawable/ic_mail_outline_grey_500_18dp"
                 android:drawablePadding="8dp"
+                android:drawableStart="@drawable/ic_mail_outline_grey_500_18dp"
                 android:textSize="@dimen/standard_font_size"
+                app:corners="8"
                 app:height_weight="0.8"
-                app:width_weight="0.9"
-                app:corners="8" />
+                app:width_weight="0.9" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Sample Loader View</string>
     <string name="btn_reset">Reset Loaders</string>
+    <string name="title">Loaded %d presidents</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath "com.github.dcendents:android-maven-gradle-plugin:1.5"
 
@@ -17,9 +18,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com'
-        }
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/loaderviewlibrary/build.gradle
+++ b/loaderviewlibrary/build.gradle
@@ -6,12 +6,12 @@ group = 'com.elyeproj.libraries'
 version = '1.4.1'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 12
         versionName "1.4.1"
     }
@@ -24,9 +24,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:27.1.0'
 }
 
 task generateSourcesJar(type: Jar) {

--- a/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderTextView.java
+++ b/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderTextView.java
@@ -27,7 +27,9 @@ import android.util.AttributeSet;
 
 public class LoaderTextView extends AppCompatTextView implements LoaderView {
 
+    private static final int NO_PLACEHOLDER = -1;
     private LoaderController loaderController;
+    private String placeholderText;
 
     public LoaderTextView(Context context) {
         super(context);
@@ -52,6 +54,8 @@ public class LoaderTextView extends AppCompatTextView implements LoaderView {
         loaderController.setUseGradient(typedArray.getBoolean(R.styleable.loader_view_use_gradient, LoaderConstant.USE_GRADIENT_DEFAULT));
         loaderController.setCorners(typedArray.getInt(R.styleable.loader_view_corners, LoaderConstant.CORNER_DEFAULT));
         typedArray.recycle();
+
+        checkPlaceholderAttributes(attrs);
     }
 
     @Override
@@ -103,5 +107,65 @@ public class LoaderTextView extends AppCompatTextView implements LoaderView {
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         loaderController.removeAnimatorUpdateListener();
+    }
+
+    private void checkPlaceholderAttributes(AttributeSet attrs) {
+        TypedArray typedArray = getContext().obtainStyledAttributes(attrs, R.styleable.LoaderTextView, 0, 0);
+        int placeholderTextRes =
+                typedArray.getResourceId(R.styleable.LoaderTextView_placeholder_resource, NO_PLACEHOLDER);
+        String stringArgument =
+                typedArray.getNonResourceString(R.styleable.LoaderTextView_placeholder_string_argument);
+        int intArgument =
+                typedArray.getInt(R.styleable.LoaderTextView_placeholder_int_argument, NO_PLACEHOLDER);
+        float floatPlaceholder = (float) NO_PLACEHOLDER;
+        float floatArgument =
+                typedArray.getFloat(R.styleable.LoaderTextView_placeholder_float_argument, floatPlaceholder);
+
+        if (placeholderTextRes != NO_PLACEHOLDER) {
+            Object argument = null;
+            if (stringArgument != null) {
+                argument = stringArgument;
+            }
+            else if (intArgument != NO_PLACEHOLDER) {
+                argument = intArgument;
+            }
+            else if (floatArgument != floatPlaceholder) {
+                argument = floatArgument;
+            }
+
+            placeholderText = getResources().getString(placeholderTextRes, argument);
+            measurePlaceholderTextAndSetMinWidth();
+        }
+
+        typedArray.recycle();
+    }
+
+    private void measurePlaceholderTextAndSetMinWidth() {
+        if (placeholderText == null) {
+            setMinimumWidth(0);
+            return;
+        }
+
+        float measuredWidth = getPaint().measureText(placeholderText);
+        setMinimumWidth((int) measuredWidth);
+    }
+
+    /**
+     * @return The text that is used to measure the required minimum width.
+     */
+    public String getPlaceholderText() {
+        return placeholderText;
+    }
+
+    /**
+     * Setting a placeholder text will not set any text on this {@code TextView}, but measure the minimum width
+     * based on this text, making the shimmer effect as large as the {@code placeholderText} width.
+     *
+     * @param placeholderText A text that will most likely be the actual text of this {@code TextView} later, so the
+     *                        shimmer effect has a width matching the text.
+     */
+    public void setPlaceholderText(final String placeholderText) {
+        this.placeholderText = placeholderText;
+        measurePlaceholderTextAndSetMinWidth();
     }
 }

--- a/loaderviewlibrary/src/main/res/values/attrs.xml
+++ b/loaderviewlibrary/src/main/res/values/attrs.xml
@@ -6,4 +6,11 @@
         <attr name="use_gradient" format="boolean" />
         <attr name="corners" format="integer" />
     </declare-styleable>
+
+    <declare-styleable name="LoaderTextView">
+        <attr name="placeholder_resource" format="reference"/>
+        <attr name="placeholder_string_argument" format="string" />
+        <attr name="placeholder_int_argument" format="integer" />
+        <attr name="placeholder_float_argument" format="float" />
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
Hey,

I recently integrated your library in my project and extended `LoaderTextView` so it has a more accurate size for the shimmer effect, based on a text that looks approximately like the actual text set later.

Example: We have a string template "Number %d" where the actual number is coming from remote. I want to show the loading view until I have the number. Right now I have to set `android:width` to some value, but it will never look very exact. Also in different languages the width may differ so it will mess up again.

But I already know that my text will look like "Number 15", so I added the possibility to define a String resource and optionally an argument, that `LoaderTextView` will use to calculate the width the `TextView` will have. So, in most cases I tested, the shimmer effect has the correct width of the text I set.