### PR TITLE
Prevent partial overlay if view reused quickly in RV

### DIFF
--- a/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderController.java
+++ b/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderController.java
@@ -142,5 +142,6 @@ class LoaderController implements ValueAnimator.AnimatorUpdateListener {
             valueAnimator.removeUpdateListener(this);
             valueAnimator.cancel();
         }
+        progress = 0f;
     }
 }


### PR DESCRIPTION
If a loader view is used within a view holder in a large recycler view, and the user scrolls quickly it's possible for the view to be reused with a non-zero `progress` and without starting an animation. This results in randomly getting static overlays on images/text.

This fixes that by setting `progress` to 0 when the animator listener is removed. When the view is drawn next, the now 0'd progress is used to drive the alpha in the `onDraw` method and thus no overlay is drawn.