### PR TITLE
 Let loader views respect 'android:gravity' and 'android:textAlignment'

### DIFF
--- a/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderController.java
+++ b/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderController.java
@@ -5,9 +5,13 @@ import android.animation.ValueAnimator;
 import android.graphics.Canvas;
 import android.graphics.LinearGradient;
 import android.graphics.Paint;
+import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Shader;
 import android.view.animation.LinearInterpolator;
+import androidx.core.text.TextUtilsCompat;
+import androidx.core.view.GravityCompat;
+import java.util.Locale;
 
 /*
  * Copyright 2016 Elye Project
@@ -36,6 +40,7 @@ class LoaderController implements ValueAnimator.AnimatorUpdateListener {
     private float heightWeight = LoaderConstant.MAX_WEIGHT;
     private boolean useGradient = LoaderConstant.USE_GRADIENT_DEFAULT;
     private int corners = LoaderConstant.CORNER_DEFAULT;
+    private RectF loaderContainer;
 
     private final static int MAX_COLOR_CONSTANT_VALUE = 255;
     private final static int ANIMATION_CYCLE_DURATION = 750; //milis
@@ -56,21 +61,17 @@ class LoaderController implements ValueAnimator.AnimatorUpdateListener {
     }
 
     public void onDraw(Canvas canvas, float left_pad, float top_pad, float right_pad, float bottom_pad) {
-        float margin_height = canvas.getHeight() * (1 - heightWeight) / 2;
         rectPaint.setAlpha((int) (progress * MAX_COLOR_CONSTANT_VALUE));
         if (useGradient) {
             prepareGradient(canvas.getWidth() * widthWeight);
         }
-        canvas.drawRoundRect(new RectF(0 + left_pad,
-                        margin_height + top_pad,
-                        canvas.getWidth() * widthWeight - right_pad,
-                        canvas.getHeight() - margin_height - bottom_pad),
-                corners, corners,
-                rectPaint);
+        prepareLoaderContainer(canvas, left_pad, top_pad, right_pad, bottom_pad);
+        canvas.drawRoundRect(loaderContainer, corners, corners, rectPaint);
     }
 
     public void onSizeChanged() {
         linearGradient = null;
+        loaderContainer = null;
         startLoading();
     }
 
@@ -80,6 +81,23 @@ class LoaderController implements ValueAnimator.AnimatorUpdateListener {
                     LoaderConstant.COLOR_DEFAULT_GRADIENT, Shader.TileMode.MIRROR);
         }
         rectPaint.setShader(linearGradient);
+    }
+
+    private void prepareLoaderContainer(Canvas canvas, float left_pad, float top_pad, float right_pad, float bottom_pad) {
+        if (loaderContainer != null) {
+            return;
+        }
+        final Rect outRect = new Rect();
+        GravityCompat.apply(loaderView.getLoaderGravity(),
+                Math.round(canvas.getWidth() * widthWeight),
+                Math.round(canvas.getHeight() * heightWeight),
+                new Rect(0, 0, canvas.getWidth(), canvas.getHeight()),
+                outRect,
+                TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()));
+        loaderContainer = new RectF(outRect.left + left_pad,
+                outRect.top + top_pad,
+                outRect.right - right_pad,
+                outRect.bottom - bottom_pad);
     }
 
     public void startLoading() {

--- a/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderController.java
+++ b/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderController.java
@@ -9,8 +9,10 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Shader;
 import android.view.animation.LinearInterpolator;
+
 import androidx.core.text.TextUtilsCompat;
 import androidx.core.view.GravityCompat;
+
 import java.util.Locale;
 
 /*
@@ -91,13 +93,13 @@ class LoaderController implements ValueAnimator.AnimatorUpdateListener {
         GravityCompat.apply(loaderView.getLoaderGravity(),
                 Math.round(canvas.getWidth() * widthWeight),
                 Math.round(canvas.getHeight() * heightWeight),
-                new Rect(0, 0, canvas.getWidth(), canvas.getHeight()),
+                new Rect(Math.round(left_pad),
+                        Math.round(top_pad),
+                        Math.round(canvas.getWidth() - right_pad),
+                        Math.round(canvas.getHeight() - bottom_pad)),
                 outRect,
                 TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault()));
-        loaderContainer = new RectF(outRect.left + left_pad,
-                outRect.top + top_pad,
-                outRect.right - right_pad,
-                outRect.bottom - bottom_pad);
+        loaderContainer = new RectF(outRect.left, outRect.top, outRect.right, outRect.bottom);
     }
 
     public void startLoading() {

--- a/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderImageView.java
+++ b/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderImageView.java
@@ -24,6 +24,7 @@ import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.Icon;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import androidx.appcompat.widget.AppCompatImageView;
 import androidx.core.content.ContextCompat;
 
@@ -83,6 +84,11 @@ public class LoaderImageView extends AppCompatImageView implements LoaderView {
     @Override
     public boolean valueSet() {
         return (getDrawable() != null);
+    }
+
+    @Override
+    public int getLoaderGravity() {
+        return Gravity.NO_GRAVITY;
     }
 
     @Override

--- a/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderTextView.java
+++ b/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderTextView.java
@@ -16,7 +16,6 @@ package com.elyeproj.loaderviewlibrary;
  * limitations under the License.
  */
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -51,7 +50,6 @@ public class LoaderTextView extends AppCompatTextView implements LoaderView {
         init(attrs);
     }
 
-    @SuppressLint("SwitchIntDef")
     private void init(AttributeSet attrs) {
         loaderController = new LoaderController(this);
         TypedArray typedArray = getContext().obtainStyledAttributes(attrs, R.styleable.loader_view, 0, 0);

--- a/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderTextView.java
+++ b/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderTextView.java
@@ -16,13 +16,16 @@ package com.elyeproj.loaderviewlibrary;
  * limitations under the License.
  */
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Typeface;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.content.ContextCompat;
 
@@ -31,6 +34,7 @@ public class LoaderTextView extends AppCompatTextView implements LoaderView {
     private LoaderController loaderController;
     private int defaultColorResource;
     private int darkerColorResource;
+    private int loaderGravity;
 
     public LoaderTextView(Context context) {
         super(context);
@@ -47,6 +51,7 @@ public class LoaderTextView extends AppCompatTextView implements LoaderView {
         init(attrs);
     }
 
+    @SuppressLint("SwitchIntDef")
     private void init(AttributeSet attrs) {
         loaderController = new LoaderController(this);
         TypedArray typedArray = getContext().obtainStyledAttributes(attrs, R.styleable.loader_view, 0, 0);
@@ -57,6 +62,23 @@ public class LoaderTextView extends AppCompatTextView implements LoaderView {
         defaultColorResource = typedArray.getColor(R.styleable.loader_view_custom_color, ContextCompat.getColor(getContext(), R.color.default_color));
         darkerColorResource = typedArray.getColor(R.styleable.loader_view_custom_color, ContextCompat.getColor(getContext(), R.color.darker_color));
         typedArray.recycle();
+        loaderGravity = getGravity();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) { // prefer text alignment when available.
+            final int verticalGravity = loaderGravity & Gravity.VERTICAL_GRAVITY_MASK;
+            switch (getTextAlignment()) {
+                case android.view.View.TEXT_ALIGNMENT_CENTER:
+                    loaderGravity = verticalGravity | Gravity.CENTER_HORIZONTAL;
+                    break;
+                case android.view.View.TEXT_ALIGNMENT_TEXT_END:
+                case android.view.View.TEXT_ALIGNMENT_VIEW_END:
+                    loaderGravity = verticalGravity | Gravity.END;
+                    break;
+                case android.view.View.TEXT_ALIGNMENT_TEXT_START:
+                case android.view.View.TEXT_ALIGNMENT_VIEW_START:
+                    loaderGravity = verticalGravity | Gravity.START;
+                    break;
+            }
+        }
     }
 
     @Override
@@ -102,6 +124,11 @@ public class LoaderTextView extends AppCompatTextView implements LoaderView {
     @Override
     public boolean valueSet() {
         return !TextUtils.isEmpty(getText());
+    }
+
+    @Override
+    public int getLoaderGravity() {
+        return loaderGravity;
     }
 
     @Override

--- a/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderView.java
+++ b/loaderviewlibrary/src/main/java/com/elyeproj/loaderviewlibrary/LoaderView.java
@@ -24,4 +24,6 @@ interface LoaderView {
     void invalidate();
 
     boolean valueSet();
+
+    int getLoaderGravity();
 }


### PR DESCRIPTION
Resolves #33 

Updated screen capture:

(Phone and email loader hints are now correctly aligned.)

![preview](https://user-images.githubusercontent.com/7106123/153773945-28fcaf27-5292-4ead-94dc-7b9bf9302513.gif)
